### PR TITLE
Updated brew install git location

### DIFF
--- a/installation-instructions/python-installation-mac.md
+++ b/installation-instructions/python-installation-mac.md
@@ -31,7 +31,7 @@ packages like Python directly from the command line.
 Open up your terminal and paste this in:
 
 ```
-ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
 
 The script should walk you through the rest of installing Homebrew. The last


### PR DESCRIPTION
Homebrew Install location has changed:

$ ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
Whoops, the Homebrew installer has moved! Please instead run:

ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

Also, please ask wherever you got this link from to update it to the above.
Thanks!
